### PR TITLE
reject non-symbol property arguments by raising an ArgumentError

### DIFF
--- a/lib/persistence/sequel/identity_set_repository.rb
+++ b/lib/persistence/sequel/identity_set_repository.rb
@@ -167,6 +167,7 @@ module Persistence::Sequel
 
     # convenience to get a particular property mapper of this repo:
     def mapper(name)
+      raise ArgumentError unless name.is_a?(Symbol)
       @property_mappers[name] or raise "#{self.class}: no such property mapper #{name.inspect}"
     end
 

--- a/test/sequel_test.rb
+++ b/test/sequel_test.rb
@@ -67,6 +67,49 @@ describe "Persistence::Sequel::IdentitySetRepository" do
     assert !entity.attribute_loaded?(:def)
   end
 
+  it "should raise an ArgumentError when property name passed as a string to get_by_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_raise ArgumentError do
+      @repository.get_by_property("abc", "foo")
+    end
+  end
+
+  it "should accept a property name passed as a symbol to get_by_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_equal entity, @repository.get_by_property(:abc, "foo")
+  end
+
+  it "should raise an ArgumentError when property name passed as a string to get_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_raise ArgumentError do
+      @repository.get_property(entity, "abc", "foo")
+    end
+  end
+
+  it "should accept a property name passed as a symbol to get_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_equal "foo", @repository.get_property(entity, :abc, "foo")
+  end
+
+ it "should raise an ArgumentError when property name passed as a string to get_many_by_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_raise ArgumentError do
+      @repository.get_many_by_property("abc", "foo")
+    end
+  end
+
+  it "should accept a property name passed as a symbol to get_many_by_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_equal [entity], @repository.get_many_by_property(:abc, "foo")
+  end
+
+
   describe "map_column", self do
     it "should map a schema property to a database column of the same name" do
       @db = Sequel.sqlite


### PR DESCRIPTION
Hi there chaps,

I've noticed that calling Persistence::Sequel::IdentitySetRepository#get_by_property (and similar methods) fails in a slightly counter-intuitive way (raising "no such property mapper" if the property name is passed as a string rather than a symbol. To my mind, raising an ArgumentError would be a little more descriptive in this case, please find attached tests and a patch that will do this. Alternatively, it could be possible to allow properties to be passed as strings and convert them silently, I've also got tests and a patch for this behaviour that I'll submit in another pull request.

Cheers,

Tim 
