### PR TITLE
allow properties to be passed as strings to queries

### DIFF
--- a/lib/persistence/sequel/identity_set_repository.rb
+++ b/lib/persistence/sequel/identity_set_repository.rb
@@ -167,7 +167,7 @@ module Persistence::Sequel
 
     # convenience to get a particular property mapper of this repo:
     def mapper(name)
-      @property_mappers[name] or raise "#{self.class}: no such property mapper #{name.inspect}"
+      @property_mappers[name.to_sym] or raise "#{self.class}: no such property mapper #{name.inspect}"
     end
 
     # if you want to avoid the need to manually pass in target_repo parameters for each property

--- a/test/sequel_test.rb
+++ b/test/sequel_test.rb
@@ -67,6 +67,43 @@ describe "Persistence::Sequel::IdentitySetRepository" do
     assert !entity.attribute_loaded?(:def)
   end
 
+  it "should accept a property name passed as a string to get_by_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_equal entity, @repository.get_by_property("abc", "foo")
+  end
+
+  it "should accept a property name passed as a symbol to get_by_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_equal entity, @repository.get_by_property(:abc, "foo")
+  end
+
+  it "should accept a property name passed as a string to get_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_equal "foo", @repository.get_property(entity, "abc", "foo")
+  end
+
+  it "should accept a property name passed as a symbol to get_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_equal "foo", @repository.get_property(entity, :abc, "foo")
+  end
+
+ it "should accept a property name passed as a string to get_many_by_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_equal [entity], @repository.get_many_by_property("abc", "foo")
+  end
+
+  it "should accept a property name passed as a symbol to get_many_by_property" do
+    entity = make_entity(:id => 1, :abc => 'foo', :def => 'bar')
+    @repository.store_new(entity)
+    assert_equal [entity], @repository.get_many_by_property(:abc, "foo")
+  end
+
+
   describe "map_column", self do
     it "should map a schema property to a database column of the same name" do
       @db = Sequel.sqlite


### PR DESCRIPTION
See https://github.com/playlouder/persistence/pull/2

This is an alternative remedy to the same issue, that allow properties to be passed as strings and convert them silently.
